### PR TITLE
Updated Multirun.gd to Godot 4

### DIFF
--- a/addons/multirun/Multirun.gd
+++ b/addons/multirun/Multirun.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends EditorPlugin
 
 var panel1
@@ -7,10 +7,10 @@ var pids = []
 
 func _enter_tree():
 	var editor_node = get_tree().get_root().get_child(0)
-	var gui_base = editor_node.get_gui_base()
-	var icon_transition = gui_base.get_icon("TransitionSync", "EditorIcons") #ToolConnect
-	var icon_transition_auto = gui_base.get_icon("TransitionSyncAuto", "EditorIcons")
-	var icon_load = gui_base.get_icon("Load", "EditorIcons")
+	var gui_base : Panel = editor_node.get_gui_base()
+	var icon_transition = gui_base.get_theme_icon("TransitionSync", "EditorIcons") #ToolConnect
+	var icon_transition_auto = gui_base.get_theme_icon("TransitionSyncAuto", "EditorIcons")
+	var icon_load = gui_base.get_theme_icon("Load", "EditorIcons")
 	
 	panel2 = _add_tooblar_button("_loaddir_pressed", icon_load, icon_load)
 	panel1 = _add_tooblar_button("_multirun_pressed", icon_transition, icon_transition_auto)
@@ -28,7 +28,7 @@ func _multirun_pressed():
 	var first_args : String = ProjectSettings.get_setting("debug/multirun/first_window_args")
 	var other_args : String = ProjectSettings.get_setting("debug/multirun/other_window_args")
 	var commands = ["--position", "50,10"]
-	if first_args && add_custom_args:
+	if first_args != "" && add_custom_args:
 		for arg in first_args.split(" "):
 			commands.push_front(arg)
 
@@ -43,10 +43,10 @@ func _multirun_pressed():
 	kill_pids()
 	for i in range(window_count-1):
 		commands = ["--position", str(50 + (i+1) * window_dist) + ",10"]
-		if other_args && add_custom_args:
+		if other_args != "" && add_custom_args:
 			for arg in other_args.split(" "):
 				commands.push_front(arg)
-		pids.append(OS.execute(OS.get_executable_path(), commands, false))
+		pids.append(OS.execute(OS.get_executable_path(), commands, Array(), false))
 
 func _loaddir_pressed():
 	OS.shell_open(OS.get_user_data_dir())
@@ -70,7 +70,7 @@ func _remove_panels():
 
 func _unhandled_input(event):	
 	if event is InputEventKey:
-		if event.pressed and event.scancode == KEY_F4:
+		if event.pressed and event.get_keycode_with_modifiers() == KEY_F4:
 			_multirun_pressed()
 
 func _add_tooblar_button(action:String, icon_normal, icon_pressed):
@@ -78,7 +78,7 @@ func _add_tooblar_button(action:String, icon_normal, icon_pressed):
 	var b = TextureButton.new();
 	b.texture_normal = icon_normal
 	b.texture_pressed = icon_pressed
-	b.connect("pressed", self, action)
+	b.connect("pressed", Callable(self, action))
 	panel.add_child(b)
 	add_control_to_container(CONTAINER_TOOLBAR, panel)
 	return panel


### PR DESCRIPTION
It works really well. I got the editor icon to load, the instances under the Debug tab, and in project settings the Multirun section under Debug is now showing up. I haven't had an issue using it the way I did in Godot 3 but I do get this error every time I run:

platform/windows/os_windows.cpp:686 - Condition "!process_map->has(p_pid)" is true. Returning: FAILED

I've done some work on trying to fix that but still haven't found exactly what I need to do. Maybe you'll have a clue. That being said, it would be great if we could get a Godot 4 branch.

Thanks for the awesome plugin!